### PR TITLE
Fix for dynamic scope bug in letrec

### DIFF
--- a/SchemeJSCore.mjs
+++ b/SchemeJSCore.mjs
@@ -1484,10 +1484,7 @@ export function createInstance(schemeOpts = {}) {
     }
     tools.indent = saveIndent;
     emit(`}`);
-    if (ssaScope.dynamicScopeUsed)
-      saveSsaScope.dynamicScopeUsed = true;
-    else
-      tools.deleteEmitted(scopeLines);
+    saveSsaScope.dynamicScopeUsed = true;
     return ssaResult;
   }
 
@@ -3088,12 +3085,12 @@ export function createInstance(schemeOpts = {}) {
     let binder = new Function("bound", "resolveUnbound", "invokeUnbound", code);
     let compiledFunction = binder.call(this, bindSymToObj, resolveUnbound, invokeUnbound);
     return compiledFunction;
-    function resolveUnbound(symbol) {
+    function resolveUnbound(symbol, scope) {
       let val = scope[symbol];
       if (val === undefined) return checkUndefinedInScope(symbol, scope);
       return val;
     }
-    function invokeUnbound(fn, args) {
+    function invokeUnbound(fn, args, scope) {
       let list = new Pair(fn, args);
       return _eval(list, scope);
     }
@@ -3284,7 +3281,7 @@ export function createInstance(schemeOpts = {}) {
           return ssaValue;
         }
         tools.dynamicScopeUsed = true;
-        return `resolveUnbound(${use(bind(sym))})`;
+        return `resolveUnbound(${use(bind(sym))}, scope)`;
       }
       if (TRACE_COMPILER)  // too noisy and not very informative to trace the above
         console.log("COMPILE EVAL", string(form));
@@ -3331,7 +3328,7 @@ export function createInstance(schemeOpts = {}) {
           let fName = typeof fn === 'symbol' ? fn.description : 'unbound';
           let ssaResult = newTemp(`${fName}_result`);
           let ssaArgList = use(bind(args));
-          emit(`let ${ssaResult} = invokeUnbound(${ssaFunction}, ${ssaArgList});`);
+          emit(`let ${ssaResult} = invokeUnbound(${ssaFunction}, ${ssaArgList}, scope);`);
           return ssaResult;
         }
         let requiredCount = functionDescriptor.requiredCount;

--- a/UnitTest.mjs
+++ b/UnitTest.mjs
@@ -724,6 +724,16 @@ function runTestsInNewInstance(opts = {}) {
       endTestScope(savedScope);
     }
 
+    { // Test dynamic let bindings
+      let savedScope = beginTestScope();
+      EXPECT(` (defn [f1 x] x) `, ` 'f1 `);
+      EXPECT(` (defn [f2 y] y) `, ` 'f2 `);
+      EXPECT(` (def functions [f1]) `, ` 'functions `)
+      EXPECT(` (compile [f3]  (let ((z 1)) ((nth 0 functions) (f2 z)))) `, ` 'f3 `);
+      EXPECT(` (f3) `, ` 1 `)
+      endTestScope(savedScope);
+    }
+
     { // Test that spread works OK with a macro that specializes for the compiled case.
       let savedScope = beginTestScope();
 


### PR DESCRIPTION
I stumbled upon this failing snippet:

```lisp
(defn [f x] x)
(def functions [f])
(defn [f2 y] y)

(compile [f3]
  (let ((mode 1))
   ((nth 0 functions) (f2 mode))))

(f3)
```
The call to `(f3)` should return `1`.
The error is caught by `checkUndefinedInScope`, because the `mode` binding is not found in scope.
I noticed that when `resolveUnbound` and `invokeUnbound` were called, they operate on a scope which is not a parameter and so is treated as the global scope. By adding the scope as a parameter, and also removing the condition in `letrec` which deletes the emitted `scopeLines`, it works as expected.

I ran the test suite to make sure there were no unintended consequences but they all pass. So I added an additional test for this scenario.

I do suspect that a better solution could be found if this situation could be detected, and avoid these extra lines being emitted when they are not needed.